### PR TITLE
Increase body padding and block margin in CSS

### DIFF
--- a/src/senddisc-v4/styles.css
+++ b/src/senddisc-v4/styles.css
@@ -9,7 +9,7 @@
 body {
     font-family: Inter, Roboto, Arial, sans-serif;
     margin: 0;
-    padding: 12px;
+    padding: 24px;
     width: 360px;
     color: var(--muted);
     background: linear-gradient(180deg, #0b0b0d, #0f0f12);
@@ -21,7 +21,7 @@ body {
 }
 
 .block {
-    margin-bottom: 10px
+    margin-bottom: 12px
 }
 
 .muted {


### PR DESCRIPTION
Updated the body padding from 12px to 24px and the .block margin-bottom from 10px to 12px for improved spacing and layout consistency.